### PR TITLE
Use SimpleITK from pipy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,23 @@
-FROM insighttoolkit/simpleitk-notebooks:latest
+FROM thewtex/jupyter-notebook-debian
 MAINTAINER Insight Software Consortium <community@itk.org>
 
+USER root
+
+RUN apt-get update && apt-get install -y \
+  git \
+  python3 \
+  python3-matplotlib \
+  python3-numpy \
+  python3-scipy \
+  wget
+
+RUN wget https://bootstrap.pypa.io/get-pip.py && python3 get-pip.py
+
+ADD requirements.txt ./
 ADD README.rst ./
 ADD "*.ipynb" ./
 ADD "*.py" ./
 ADD Data ./Data
 ADD Output ./Output
+RUN sudo pip3 install -r requirements.txt
 RUN sudo chown -R jovyan.jovyan ./*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+SimpleITK>=0.10.0
+jupyter
+matplotlib
+ipywidgets
+numpy


### PR DESCRIPTION
Added a python requirements.txt file to specify the require
packages. Since all packages are available in binary format on pipy,
we are now not basing the image on a "development" platform.

The Docker image is not directly derived from
thewtex/jupyter-notebook-debian.