### PR TITLE
Adding require command to enable javascript based widgets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,5 @@ ADD "*.py" ./
 ADD Data ./Data
 ADD Output ./Output
 RUN sudo pip3 install -r requirements.txt
+RUN jupyter nbextension enable --py --sys-prefix widgetsnbextension
 RUN sudo chown -R jovyan.jovyan ./*


### PR DESCRIPTION
This was found in the following issue:
https://github.com/ipython/ipywidgets/issues/541

And according to the documentation:
https://github.com/ipython/ipywidgets/blob/master/README.md#install